### PR TITLE
[registry] Add skip_http_fallback config option

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -629,6 +629,9 @@ pub struct RegistryConfig {
     /// Disable background token refresh thread. Defaults to false.
     #[serde(skip_deserializing)]
     pub disable_token_refresh: bool,
+    /// Prevent automatic fallback from HTTPS to HTTP on TLS errors.
+    #[serde(default)]
+    pub skip_http_fallback: bool,
 }
 
 /// Configuration information for blob cache manager.

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -203,6 +203,8 @@ struct RegistryState {
     blob_url_scheme: String,
     // Replace registry redirected url host with the given host
     blob_redirected_host: String,
+    // Prevent automatic fallback from HTTPS to HTTP on TLS errors
+    skip_http_fallback: bool,
     // Cache bearer token (get from registry authentication server) or basic authentication auth string.
     // We need use it to reduce the pressure on token authentication server or reduce the base64 compute workload for every request.
     // Use RwLock here to avoid using mut backend trait object.
@@ -238,6 +240,9 @@ impl RegistryState {
     }
 
     fn needs_fallback_http(&self, e: &dyn Error) -> bool {
+        if self.skip_http_fallback {
+            return false;
+        }
         match e.source() {
             Some(err) => match err.source() {
                 Some(err) => {
@@ -880,6 +885,7 @@ impl Registry {
             retry_limit,
             blob_url_scheme: config.blob_url_scheme.clone(),
             blob_redirected_host: config.blob_redirected_host.clone(),
+            skip_http_fallback: config.skip_http_fallback,
             cached_auth_using_http_get: HashCache::new(),
             cached_redirect: HashCache::new(),
             token_expired_at: ArcSwapOption::new(None),
@@ -1066,6 +1072,7 @@ mod tests {
             retry_limit: 5,
             blob_url_scheme: "https".to_string(),
             blob_redirected_host: "oss.alibaba-inc.com".to_string(),
+            skip_http_fallback: false,
             cached_auth_using_http_get: Default::default(),
             cached_auth: Default::default(),
             cached_redirect: Default::default(),


### PR DESCRIPTION
Allow disabling the automatic HTTPS-to-HTTP downgrade that occurs on TLS connection errors. When skip_http_fallback is set to true, TLS errors propagate as-is instead of silently falling back to plaintext HTTP. Defaults to false to preserve backward compatibility.

Tested locally with the snapshotter. To make sure the config was propagated, I logged the config value when the registry object is initialized: 
```
INFO[2026-03-31T18:30:18.575502875+02:00] nydusd command: /containerd-local/nydusd fuse --config /containerd-local/io.containerd.snapshotter.v1.nydus/config/d75vd69jjoqfl2rb96jg/config.json --bootstrap /containerd-local/io.containerd.snapshotter.v1.nydus/snapshots/383/fs/image/image.boot --mountpoint /containerd-local/io.containerd.snapshotter.v1.nydus/snapshots/383/mnt --apisock /containerd-local/io.containerd.snapshotter.v1.nydus/socket/d75vd69jjoqfl2rb96jg/api.sock --log-level debug --log-rotation-size 100 --failover-policy resend
[2026-03-31 18:30:18.578553 +02:00] INFO Program Version: v2.4.0-dd-1-g829d5730, Git Commit: "829d5730a20acbb80cf8495a909d2073b733652f", Build Time: "2026-03-31T16:25:07.801752195Z", Profile: "debug", Rustc Version: "rustc 1.84.0 (9fc6b4312 2025-01-07)"
[2026-03-31 18:30:18.578618 +02:00] INFO Set rlimit-nofile to 1000000, maximum 1000000
[2026-03-31 18:30:18.579036 +02:00] DEBUG [/fuse-backend-rs-0.13.1/src/api/pseudo_fs.rs:161] pseudo fs iterate "/"
[2026-03-31 18:30:18.579317 +02:00] INFO RAFS features: HASH_BLAKE3 | EXPLICIT_UID_GID | HAS_XATTR | COMPRESSION_ZSTD | INLINED_CHUNK_DIGEST| ENCRYPTION_NONE
[2026-03-31 18:30:18.579564 +02:00] INFO backend config: ConnectionConfig { proxy: ProxyConfig { url: "", ping_url: "", fallback: false, check_interval: 5, use_http: false, check_pause_elapsed: 300 }, skip_verify: false, timeout: 15, connect_timeout: 15, retry_limit: 5 }
[2026-03-31 18:30:18.586435 +02:00] INFO Skip http fallback: true
```