### PR TITLE
nydusify commit: fix mount option parsing for volatile flag

### DIFF
--- a/contrib/nydusify/pkg/committer/manager.go
+++ b/contrib/nydusify/pkg/committer/manager.go
@@ -109,15 +109,14 @@ func (m *Manager) Inspect(ctx context.Context, containerID string) (*InspectResu
 	}
 
 	snapshot := client.SnapshotService("nydus")
-	lowerDirs := ""
-	upperDir := ""
 	mount, err := snapshot.Mounts(ctx, containerInfo.SnapshotKey)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get snapshot mount")
 	}
-	// snapshot Mount Options[0] "workdir=$workdir", Options[1] "upperdir=$upperdir", Options[2] "lowerdir=$lowerdir".
-	lowerDirs = strings.TrimPrefix(mount[0].Options[2], "lowerdir=")
-	upperDir = strings.TrimPrefix(mount[0].Options[1], "upperdir=")
+	lowerDirs, upperDir, err := parseMountOptions(mount[0].Options)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parse snapshot mount options")
+	}
 
 	return &InspectResult{
 		LowerDirs: lowerDirs,
@@ -126,4 +125,18 @@ func (m *Manager) Inspect(ctx context.Context, containerID string) (*InspectResu
 		Mounts:    mounts,
 		Pid:       pid,
 	}, nil
+}
+
+func parseMountOptions(options []string) (lowerDirs, upperDir string, err error) {
+	for _, opt := range options {
+		if strings.HasPrefix(opt, "lowerdir=") {
+			lowerDirs = strings.TrimPrefix(opt, "lowerdir=")
+		} else if strings.HasPrefix(opt, "upperdir=") {
+			upperDir = strings.TrimPrefix(opt, "upperdir=")
+		}
+	}
+	if lowerDirs == "" || upperDir == "" {
+		return "", "", errors.Errorf("snapshot mount missing lowerdir or upperdir in options: %v", options)
+	}
+	return lowerDirs, upperDir, nil
 }

--- a/contrib/nydusify/pkg/committer/manager_test.go
+++ b/contrib/nydusify/pkg/committer/manager_test.go
@@ -1,0 +1,105 @@
+package committer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMountOptions(t *testing.T) {
+	tests := []struct {
+		Name         string
+		Options      []string
+		WantLower    string
+		WantUpper    string
+		WantErr      bool
+		ErrSubstring string
+	}{
+		{
+			Name: "StandardOrder",
+			Options: []string{
+				"workdir=/var/lib/containerd/snapshots/123/work",
+				"upperdir=/var/lib/containerd/snapshots/123/fs",
+				"lowerdir=/var/lib/containerd/snapshots/100/mnt",
+			},
+			WantLower: "/var/lib/containerd/snapshots/100/mnt",
+			WantUpper: "/var/lib/containerd/snapshots/123/fs",
+		},
+		{
+			Name: "WithVolatilePrefix",
+			Options: []string{
+				"volatile",
+				"workdir=/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/1443/work",
+				"upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/1443/fs",
+				"lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/282/mnt",
+			},
+			WantLower: "/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/282/mnt",
+			WantUpper: "/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/1443/fs",
+		},
+		{
+			Name: "ReversedOrder",
+			Options: []string{
+				"lowerdir=/lower",
+				"upperdir=/upper",
+				"workdir=/work",
+			},
+			WantLower: "/lower",
+			WantUpper: "/upper",
+		},
+		{
+			Name: "MultipleLowerDirs",
+			Options: []string{
+				"workdir=/work",
+				"upperdir=/upper",
+				"lowerdir=/lower1:/lower2:/lower3",
+			},
+			WantLower: "/lower1:/lower2:/lower3",
+			WantUpper: "/upper",
+		},
+		{
+			Name: "WithIndexOff",
+			Options: []string{
+				"volatile",
+				"index=off",
+				"workdir=/work",
+				"upperdir=/upper",
+				"lowerdir=/lower",
+			},
+			WantLower: "/lower",
+			WantUpper: "/upper",
+		},
+		{
+			Name:         "MissingLowerDir",
+			Options:      []string{"workdir=/work", "upperdir=/upper"},
+			WantErr:      true,
+			ErrSubstring: "missing lowerdir or upperdir",
+		},
+		{
+			Name:         "MissingUpperDir",
+			Options:      []string{"workdir=/work", "lowerdir=/lower"},
+			WantErr:      true,
+			ErrSubstring: "missing lowerdir or upperdir",
+		},
+		{
+			Name:         "EmptyOptions",
+			Options:      []string{},
+			WantErr:      true,
+			ErrSubstring: "missing lowerdir or upperdir",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			lowerDirs, upperDir, err := parseMountOptions(tt.Options)
+			if tt.WantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.ErrSubstring)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.WantLower, lowerDirs)
+			assert.Equal(t, tt.WantUpper, upperDir)
+		})
+	}
+}


### PR DESCRIPTION
Fixes `nydusify commit` failure caused by hardcoded mount option array indices in `manager.go:Inspect()`.

The nydus snapshotter returns a `volatile` flag at index 0, shifting `workdir`/`upperdir`/`lowerdir` by one position. This leads to malformed overlay mount options (`lowerdir=upperdir=/path:...`) causing `no such file or directory` errors.

This change replaces hardcoded indices with prefix-based iteration matching the existing pattern in `overlay_linux.go:GetOverlayLayers`.

## Breadcrumbs

Jira: NODES-450
