### PR TITLE
[registry] Fix token refresh firing every 20s instead of near expiry

### DIFF
--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -33,6 +33,8 @@ const HEADER_WWW_AUTHENTICATE: &str = "www-authenticate";
 
 const REGISTRY_DEFAULT_TOKEN_EXPIRATION: u64 = 10 * 60; // in seconds
 const REGISTRY_CONFIG_POLL_INTERVAL: u64 = 5; // in seconds
+                                              // Refresh tokens this many seconds before they expire to avoid using an expired token.
+const REGISTRY_TOKEN_REFRESH_MARGIN: u64 = 20; // in seconds
 
 /// Error codes related to registry storage backend operations.
 #[derive(Debug)]
@@ -1012,8 +1014,6 @@ impl Registry {
     fn start_refresh_token_thread(&self) {
         let conn = self.connection.clone();
         let state = self.state.clone();
-        // FIXME: we'd better allow users to specify the expiration time.
-        let mut refresh_interval = REGISTRY_DEFAULT_TOKEN_EXPIRATION;
         thread::spawn(move || {
             loop {
                 // Check for config auth changes every tick.
@@ -1021,9 +1021,10 @@ impl Registry {
 
                 if let Ok(now_timestamp) = SystemTime::now().duration_since(UNIX_EPOCH) {
                     if let Some(token_expired_at) = state.token_expired_at.load().as_deref() {
-                        // If the token will expire within the next refresh interval,
-                        // refresh it immediately.
-                        if now_timestamp.as_secs() + refresh_interval >= *token_expired_at {
+                        // Refresh the token if it will expire within the margin.
+                        if now_timestamp.as_secs() + REGISTRY_TOKEN_REFRESH_MARGIN
+                            >= *token_expired_at
+                        {
                             if let Some(cached_bearer_auth) =
                                 state.cached_bearer_auth.load().as_deref()
                             {
@@ -1034,16 +1035,9 @@ impl Registry {
                                     debug!(
                                         "[refresh_token_thread] registry token has been refreshed"
                                     );
-                                    // Refresh cached token.
                                     state
                                         .cached_auth
                                         .set(&state.cached_auth.get(), new_cached_auth);
-                                    // Reset refresh interval according to real expiration time,
-                                    // and advance 20s to handle the unexpected cases.
-                                    refresh_interval = token
-                                        .expires_in
-                                        .checked_sub(20)
-                                        .unwrap_or(token.expires_in);
                                 } else {
                                     error!(
                                         "[refresh_token_thread] failed to refresh registry token"


### PR DESCRIPTION
The refresh_interval variable was set to expires_in - 20 after each refresh, then used in the check `now + refresh_interval >= expired_at`. Since expired_at = fetch_time + expires_in, this resolved to "refresh when 20s have passed since last fetch" rather than "refresh 20s before expiry".

Replace the mutable refresh_interval with a fixed margin constant so the check correctly triggers only when the token is about to expire within the next 20 seconds.
