### PR TITLE
Add custom trusted CA parameter to nydusd

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -583,6 +583,9 @@ pub struct HttpProxyConfig {
     /// Skip SSL certificate validation for HTTPS scheme.
     #[serde(default)]
     pub skip_verify: bool,
+    /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
+    #[serde(default)]
+    pub ca_cert_files: Vec<String>,
     /// Drop the read request once http request timeout, in seconds.
     #[serde(default = "default_http_timeout")]
     pub timeout: u32,

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -620,14 +620,6 @@ pub struct RegistryConfig {
     /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
     #[serde(default)]
     pub ca_cert_files: Vec<String>,
-    /// Path to a PEM-encoded client certificate file for mTLS authentication.
-    /// Must be used together with `client_key_file`.
-    #[serde(default)]
-    pub client_cert_file: Option<String>,
-    /// Path to a PEM-encoded private key file for mTLS authentication.
-    /// Must be used together with `client_cert_file`.
-    #[serde(default)]
-    pub client_key_file: Option<String>,
     /// Drop the read request once http request timeout, in seconds.
     #[serde(default = "default_http_timeout")]
     pub timeout: u32,

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -504,6 +504,9 @@ pub struct OssConfig {
     /// Skip SSL certificate validation for HTTPS scheme.
     #[serde(default)]
     pub skip_verify: bool,
+    /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
+    #[serde(default)]
+    pub ca_cert_files: Vec<String>,
     /// Drop the read request once http request timeout, in seconds.
     #[serde(default = "default_http_timeout")]
     pub timeout: u32,
@@ -548,6 +551,9 @@ pub struct S3Config {
     /// Skip SSL certificate validation for HTTPS scheme.
     #[serde(default)]
     pub skip_verify: bool,
+    /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
+    #[serde(default)]
+    pub ca_cert_files: Vec<String>,
     /// Drop the read request once http request timeout, in seconds.
     #[serde(default = "default_http_timeout")]
     pub timeout: u32,
@@ -611,6 +617,17 @@ pub struct RegistryConfig {
     /// When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
     #[serde(default)]
     pub skip_verify: bool,
+    /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
+    #[serde(default)]
+    pub ca_cert_files: Vec<String>,
+    /// Path to a PEM-encoded client certificate file for mTLS authentication.
+    /// Must be used together with `client_key_file`.
+    #[serde(default)]
+    pub client_cert_file: Option<String>,
+    /// Path to a PEM-encoded private key file for mTLS authentication.
+    /// Must be used together with `client_cert_file`.
+    #[serde(default)]
+    pub client_key_file: Option<String>,
     /// Drop the read request once http request timeout, in seconds.
     #[serde(default = "default_http_timeout")]
     pub timeout: u32,

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -260,6 +260,15 @@ Document located at: https://github.com/adamqqqplay/nydus-localdisk/blob/master/
         // Skip SSL certificate validation for HTTPS scheme.
         // When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
         "skip_verify": false,
+        // Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+        // Useful when the registry uses a private or self-signed CA.
+        "ca_cert_files": ["/etc/ssl/certs/my-ca.pem"],
+        // Path to a PEM-encoded client certificate file for mTLS authentication, optional.
+        // Must be used together with `client_key_file`.
+        "client_cert_file": "/etc/ssl/certs/client.pem",
+        // Path to a PEM-encoded private key file for mTLS authentication, optional.
+        // Must be used together with `client_cert_file`.
+        "client_key_file": "/etc/ssl/private/client-key.pem",
         // Use format `$namespace/$repo` (no image tag)
         "repo": "test/repo",
         // Username and password for auth

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -263,12 +263,6 @@ Document located at: https://github.com/adamqqqplay/nydus-localdisk/blob/master/
         // Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
         // Useful when the registry uses a private or self-signed CA.
         "ca_cert_files": ["/etc/ssl/certs/my-ca.pem"],
-        // Path to a PEM-encoded client certificate file for mTLS authentication, optional.
-        // Must be used together with `client_key_file`.
-        "client_cert_file": "/etc/ssl/certs/client.pem",
-        // Path to a PEM-encoded private key file for mTLS authentication, optional.
-        // Must be used together with `client_cert_file`.
-        "client_key_file": "/etc/ssl/private/client-key.pem",
         // Use format `$namespace/$repo` (no image tag)
         "repo": "test/repo",
         // Username and password for auth

--- a/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
+++ b/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
@@ -31,6 +31,9 @@ access_key_id = "my_access_key_id"
 access_key_secret = "my_access_key_secret"
 # Skip SSL certificate validation for HTTPS scheme.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the endpoint uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.
@@ -74,6 +77,15 @@ auth = "base64_encoded"
 # Skip SSL certificate validation for HTTPS scheme.
 # When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the registry uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
+# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
+# Must be used together with client_key_file.
+# client_cert_file = "/etc/ssl/certs/client.pem"
+# Path to a PEM-encoded private key file for mTLS authentication, optional.
+# Must be used together with client_cert_file.
+# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
+++ b/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
@@ -80,12 +80,6 @@ skip_verify = true
 # Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
 # Useful when the registry uses a private or self-signed CA.
 # ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
-# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
-# Must be used together with client_key_file.
-# client_cert_file = "/etc/ssl/certs/client.pem"
-# Path to a PEM-encoded private key file for mTLS authentication, optional.
-# Must be used together with client_cert_file.
-# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-blob-cache-entry.toml
+++ b/misc/configs/nydusd-blob-cache-entry.toml
@@ -85,12 +85,6 @@ skip_verify = true
 # Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
 # Useful when the registry uses a private or self-signed CA.
 # ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
-# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
-# Must be used together with client_key_file.
-# client_cert_file = "/etc/ssl/certs/client.pem"
-# Path to a PEM-encoded private key file for mTLS authentication, optional.
-# Must be used together with client_cert_file.
-# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-blob-cache-entry.toml
+++ b/misc/configs/nydusd-blob-cache-entry.toml
@@ -36,6 +36,9 @@ access_key_id = "my_access_key_id"
 access_key_secret = "my_access_key_secret"
 # Skip SSL certificate validation for HTTPS scheme.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the endpoint uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.
@@ -79,6 +82,15 @@ auth = "base64_encoded"
 # Skip SSL certificate validation for HTTPS scheme.
 # When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the registry uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
+# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
+# Must be used together with client_key_file.
+# client_cert_file = "/etc/ssl/certs/client.pem"
+# Path to a PEM-encoded private key file for mTLS authentication, optional.
+# Must be used together with client_cert_file.
+# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-config-v2.toml
+++ b/misc/configs/nydusd-config-v2.toml
@@ -29,6 +29,9 @@ access_key_id = "my_access_key_id"
 access_key_secret = "my_access_key_secret"
 # Skip SSL certificate validation for HTTPS scheme.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the endpoint uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.
@@ -72,6 +75,15 @@ auth = "base64_encoded"
 # Skip SSL certificate validation for HTTPS scheme.
 # When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the registry uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
+# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
+# Must be used together with client_key_file.
+# client_cert_file = "/etc/ssl/certs/client.pem"
+# Path to a PEM-encoded private key file for mTLS authentication, optional.
+# Must be used together with client_cert_file.
+# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-config-v2.toml
+++ b/misc/configs/nydusd-config-v2.toml
@@ -78,12 +78,6 @@ skip_verify = true
 # Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
 # Useful when the registry uses a private or self-signed CA.
 # ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
-# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
-# Must be used together with client_key_file.
-# client_cert_file = "/etc/ssl/certs/client.pem"
-# Path to a PEM-encoded private key file for mTLS authentication, optional.
-# Must be used together with client_cert_file.
-# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-config.json
+++ b/misc/configs/nydusd-config.json
@@ -5,7 +5,11 @@
       "config": {
         "timeout": 5,
         "connect_timeout": 5,
-        "retry_limit": 2
+        "retry_limit": 2,
+        "skip_verify": false,
+        "ca_cert_files": ["/etc/ssl/certs/my-ca.pem"],
+        "client_cert_file": "/etc/ssl/certs/client.pem",
+        "client_key_file": "/etc/ssl/private/client-key.pem"
       }
     },
     "cache": {

--- a/misc/configs/nydusd-config.json
+++ b/misc/configs/nydusd-config.json
@@ -7,9 +7,7 @@
         "connect_timeout": 5,
         "retry_limit": 2,
         "skip_verify": false,
-        "ca_cert_files": ["/etc/ssl/certs/my-ca.pem"],
-        "client_cert_file": "/etc/ssl/certs/client.pem",
-        "client_key_file": "/etc/ssl/private/client-key.pem"
+        "ca_cert_files": ["/etc/ssl/certs/my-ca.pem"]
       }
     },
     "cache": {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -28,7 +28,6 @@ nix = "0.24"
 reqwest = { version = "0.12.28", features = [
     "blocking",
     "json",
-    "native-tls",
 ], optional = true }
 rusqlite = { version = "0.30", features = ["bundled"], optional = true }
 r2d2 = { version = "0.8", optional = true }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -28,6 +28,7 @@ nix = "0.24"
 reqwest = { version = "0.12.28", features = [
     "blocking",
     "json",
+    "native-tls",
 ], optional = true }
 rusqlite = { version = "0.30", features = ["bundled"], optional = true }
 r2d2 = { version = "0.8", optional = true }

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -74,6 +74,12 @@ pub(crate) struct ConnectionConfig {
     pub timeout: u32,
     pub connect_timeout: u32,
     pub retry_limit: u8,
+    /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
+    pub ca_cert_files: Vec<String>,
+    /// Path to a PEM-encoded client certificate file for mTLS authentication.
+    pub client_cert_file: Option<String>,
+    /// Path to a PEM-encoded private key file for mTLS authentication.
+    pub client_key_file: Option<String>,
 }
 
 impl Default for ConnectionConfig {
@@ -85,6 +91,9 @@ impl Default for ConnectionConfig {
             timeout: 5,
             connect_timeout: 5,
             retry_limit: 0,
+            ca_cert_files: Vec::new(),
+            client_cert_file: None,
+            client_key_file: None,
         }
     }
 }
@@ -98,6 +107,9 @@ impl From<OssConfig> for ConnectionConfig {
             timeout: c.timeout,
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
+            ca_cert_files: c.ca_cert_files,
+            client_cert_file: None,
+            client_key_file: None,
         }
     }
 }
@@ -111,6 +123,9 @@ impl From<S3Config> for ConnectionConfig {
             timeout: c.timeout,
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
+            ca_cert_files: c.ca_cert_files,
+            client_cert_file: None,
+            client_key_file: None,
         }
     }
 }
@@ -124,6 +139,9 @@ impl From<RegistryConfig> for ConnectionConfig {
             timeout: c.timeout,
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
+            ca_cert_files: c.ca_cert_files,
+            client_cert_file: c.client_cert_file,
+            client_key_file: c.client_key_file,
         }
     }
 }
@@ -137,6 +155,9 @@ impl From<HttpProxyConfig> for ConnectionConfig {
             timeout: c.timeout,
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
+            ca_cert_files: Vec::new(),
+            client_cert_file: None,
+            client_key_file: None,
         }
     }
 }
@@ -658,6 +679,22 @@ impl Connection {
 
         if config.skip_verify {
             cb = cb.danger_accept_invalid_certs(true);
+        }
+
+        for ca_cert_file in &config.ca_cert_files {
+            let pem = std::fs::read(ca_cert_file).map_err(|e| einval!(e))?;
+            let cert = reqwest::Certificate::from_pem(&pem).map_err(|e| einval!(e))?;
+            cb = cb.add_root_certificate(cert);
+        }
+
+        if let (Some(cert_file), Some(key_file)) =
+            (&config.client_cert_file, &config.client_key_file)
+        {
+            let cert_pem = std::fs::read(cert_file).map_err(|e| einval!(e))?;
+            let key_pem = std::fs::read(key_file).map_err(|e| einval!(e))?;
+            let identity = reqwest::Identity::from_pkcs8_pem(&cert_pem, &key_pem)
+                .map_err(|e| einval!(e))?;
+            cb = cb.identity(identity);
         }
 
         if !proxy.is_empty() {

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -76,10 +76,6 @@ pub(crate) struct ConnectionConfig {
     pub retry_limit: u8,
     /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
     pub ca_cert_files: Vec<String>,
-    /// Path to a PEM-encoded client certificate file for mTLS authentication.
-    pub client_cert_file: Option<String>,
-    /// Path to a PEM-encoded private key file for mTLS authentication.
-    pub client_key_file: Option<String>,
 }
 
 impl Default for ConnectionConfig {
@@ -92,8 +88,6 @@ impl Default for ConnectionConfig {
             connect_timeout: 5,
             retry_limit: 0,
             ca_cert_files: Vec::new(),
-            client_cert_file: None,
-            client_key_file: None,
         }
     }
 }
@@ -108,8 +102,6 @@ impl From<OssConfig> for ConnectionConfig {
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
             ca_cert_files: c.ca_cert_files,
-            client_cert_file: None,
-            client_key_file: None,
         }
     }
 }
@@ -124,8 +116,6 @@ impl From<S3Config> for ConnectionConfig {
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
             ca_cert_files: c.ca_cert_files,
-            client_cert_file: None,
-            client_key_file: None,
         }
     }
 }
@@ -140,8 +130,6 @@ impl From<RegistryConfig> for ConnectionConfig {
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
             ca_cert_files: c.ca_cert_files,
-            client_cert_file: c.client_cert_file,
-            client_key_file: c.client_key_file,
         }
     }
 }
@@ -156,8 +144,6 @@ impl From<HttpProxyConfig> for ConnectionConfig {
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
             ca_cert_files: Vec::new(),
-            client_cert_file: None,
-            client_key_file: None,
         }
     }
 }
@@ -685,16 +671,6 @@ impl Connection {
             let pem = std::fs::read(ca_cert_file).map_err(|e| einval!(e))?;
             let cert = reqwest::Certificate::from_pem(&pem).map_err(|e| einval!(e))?;
             cb = cb.add_root_certificate(cert);
-        }
-
-        if let (Some(cert_file), Some(key_file)) =
-            (&config.client_cert_file, &config.client_key_file)
-        {
-            let cert_pem = std::fs::read(cert_file).map_err(|e| einval!(e))?;
-            let key_pem = std::fs::read(key_file).map_err(|e| einval!(e))?;
-            let identity =
-                reqwest::Identity::from_pkcs8_pem(&cert_pem, &key_pem).map_err(|e| einval!(e))?;
-            cb = cb.identity(identity);
         }
 
         if !proxy.is_empty() {

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -143,7 +143,7 @@ impl From<HttpProxyConfig> for ConnectionConfig {
             timeout: c.timeout,
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
-            ca_cert_files: Vec::new(),
+            ca_cert_files: c.ca_cert_files,
         }
     }
 }

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -692,8 +692,8 @@ impl Connection {
         {
             let cert_pem = std::fs::read(cert_file).map_err(|e| einval!(e))?;
             let key_pem = std::fs::read(key_file).map_err(|e| einval!(e))?;
-            let identity = reqwest::Identity::from_pkcs8_pem(&cert_pem, &key_pem)
-                .map_err(|e| einval!(e))?;
+            let identity =
+                reqwest::Identity::from_pkcs8_pem(&cert_pem, &key_pem).map_err(|e| einval!(e))?;
             cb = cb.identity(identity);
         }
 


### PR DESCRIPTION
## Overview
Currently, nydusd is only relying on the system CA when doing outbound TLS connection to a registry. This PR adds a parameter to inject some trusted CA to nydusd. 

The final objective is to inject the CA from nydus-snapshotter that get [ca from containerd hosts.toml](https://github.com/containerd/containerd/blob/main/docs/hosts.md#ca-field)

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.