### PR TITLE
CI: FIPS build

### DIFF
--- a/.github/workflows/release-dd.yml
+++ b/.github/workflows/release-dd.yml
@@ -59,6 +59,7 @@ jobs:
         arch: [amd64, arm64]
     env:
       DOCKER: false
+      GOFIPS140: v1.0.0
     steps:
     - uses: actions/checkout@v4
     - name: Setup Golang
@@ -71,6 +72,13 @@ jobs:
         make -e GOARCH=${{ matrix.arch }} contrib-release
         sudo mv contrib/nydusify/cmd/nydusify .
         sudo mv contrib/nydus-overlayfs/bin/nydus-overlayfs .
+    - name: verify FIPS build info
+      run: |
+        for bin in nydusify nydus-overlayfs; do
+          echo "Checking $bin"
+          go version -m "$bin" | grep -q 'GOFIPS140=v1.0.0' \
+            || { echo "ERROR: $bin not built with GOFIPS140=v1.0.0"; exit 1; }
+        done
     - name: store-artifacts
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
# Description

Build all nydus Go binaries with FIPS support (`nydusify` & `nydus-overlayfs`). We already have Go set to 1.24:
https://github.com/DataDog/nydus/blob/dae0b95ecc5afdf419c64c3cfabc4e2cd08b4d18/go.work#L1

References:
- https://go.dev/blog/fips140
- https://go.dev/doc/security/fips140

# Testing

CI job succeeded, verification passed: https://github.com/DataDog/nydus/actions/runs/26574142873/job/78288760457?pr=36